### PR TITLE
Fix pasted HTML being detected as MJML

### DIFF
--- a/MJML.tmLanguage
+++ b/MJML.tmLanguage
@@ -7,7 +7,7 @@
 		<string>mjml</string>
 	</array>
 	<key>firstLineMatch</key>
-	<string>&lt;!(?i:DOCTYPE)|&lt;(?i:mjml)|&lt;\?(?i:php)</string>
+	<string>&lt;(?i:mjml)</string>
 	<key>foldingStartMarker</key>
 	<string>(?x)
 		(&lt;(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|li|form|dl)\b.*?&gt;


### PR DESCRIPTION
Currently, the plugin's `.tmLanguage` contains a `firstLineMatch` expression that matches any `<!doctype ...>` tag, `<mjml>` tag, or `<?php` tag. This doesn't make much sense, since MJML documents start with an `<mjml>` tag, not either of the other two, which indicate the start of a XML/HTML or PHP file respectively. Having this `firstLineMatch` value caused pasting a HTML document into a new file in Sublime to automatically enable the MJML syntax highlighting instead of the HTML syntax highlighting.

This change fixes the regex so that it will only match `<mjml>` tags, not tags associated with other languages.

Resolves https://github.com/mjmlio/mjml-syntax/issues/13

To test this, I cloned the package to my local Packages folder (i.e. the alternate installation flow described in this package's docs) and tried pasting the following snippets of code into new tabs in Sublime:

```
<!doctype html>

test test
```

and

```
<?php

echo "test test"
```

and

```
<mjml>
  <mj-body>
  </mj-body>
</mjml>
```

Before I made this change, pasting either the HTML snippet or the MJML snippets caused Sublime to select MJML syntax highlighting. After I made this change, all three snippets trigger the correct syntax highlighting (i.e. HTML, PHP, and MJML respectively).